### PR TITLE
Missing attribute in GetRPCMethodsResponse

### DIFF
--- a/lib/generate/get_rpc_methods_response.ex
+++ b/lib/generate/get_rpc_methods_response.ex
@@ -3,6 +3,7 @@ defimpl CWMP.Protocol.Generate, for: CWMP.Protocol.Messages.GetRPCMethodsRespons
 
   def generate(req) do
     mlist=for m <- req.methods, do: element(:string, m)
-    element("cwmp:GetRPCMethodsResponse", [element(:MethodList, mlist)])
+    element("cwmp:GetRPCMethodsResponse", [
+	  element(:MethodList, %{"SOAP-ENC:arrayType": "xsd:string[#{length(mlist)}]"}, mlist)])
   end
 end


### PR DESCRIPTION
To maximize compatibility with ACS implementations, it seems better to include the soap-enc:arrayType attribute for the GetRPCMethodsResponse.