### PR TITLE
Add arrayType attributes

### DIFF
--- a/lib/generate/get_parameter_attributes.ex
+++ b/lib/generate/get_parameter_attributes.ex
@@ -3,7 +3,7 @@ defimpl CWMP.Protocol.Generate, for: CWMP.Protocol.Messages.GetParameterAttribut
 
   def generate(req) do
     params=for p <- req.parameters, do: element(:string, p)
-    element("cwmp:GetParameterAttributes", [element(:ParameterNames,[params])])
+    element("cwmp:GetParameterAttributes", [element(:ParameterNames, %{"soapenc:arrayType" => "xsd:string[#{length(params)}]"},  [params])])
   end
 end
 

--- a/lib/generate/get_parameter_values.ex
+++ b/lib/generate/get_parameter_values.ex
@@ -3,7 +3,7 @@ defimpl CWMP.Protocol.Generate, for: CWMP.Protocol.Messages.GetParameterValues d
 
   def generate(req) do
     params=for p <- req.parameters, do: element(p.type, p.name)
-    element("cwmp:GetParameterValues", [element(:ParameterNames,params)])
+    element("cwmp:GetParameterValues", [element(:ParameterNames,  %{"soapenc:arrayType" => "xsd:string[#{length(params)}]"},params)])
   end
 end
 

--- a/lib/generate/set_parameter_attributes.ex
+++ b/lib/generate/set_parameter_attributes.ex
@@ -17,6 +17,7 @@ defimpl CWMP.Protocol.Generate, for: CWMP.Protocol.Messages.SetParameterAttribut
       element(:Notification, to_string(param.notification)),
       element(:AccessListChange, boolValue(param.accesslist_change)),
       element(:AccessList, al)
+      element(:AccessList, %{"SOAP-ENC:arrayType": "xsd:string[#{length(al)}]"}, al)
     ])
   end
 end

--- a/lib/generate/set_parameter_attributes.ex
+++ b/lib/generate/set_parameter_attributes.ex
@@ -16,7 +16,6 @@ defimpl CWMP.Protocol.Generate, for: CWMP.Protocol.Messages.SetParameterAttribut
       element(:NotificationChange, boolValue(param.notification_change)),
       element(:Notification, to_string(param.notification)),
       element(:AccessListChange, boolValue(param.accesslist_change)),
-      element(:AccessList, al)
       element(:AccessList, %{"SOAP-ENC:arrayType": "xsd:string[#{length(al)}]"}, al)
     ])
   end

--- a/lib/generator.ex
+++ b/lib/generator.ex
@@ -9,7 +9,9 @@ defmodule CWMP.Protocol.Generator do
   Generates a CWMP envelope from an Elixir data structure.
   """
   def generate!(head, req, version \\ "1-4") do
-    element('SOAP-ENV:Envelope',
+
+
+    document(element('SOAP-ENV:Envelope',
       %{
         'xmlns:SOAP-ENV': "http://schemas.xmlsoap.org/soap/envelope/",
         'xmlns:SOAP-ENC': "http://schemas.xmlsoap.org/soap/encoding/",
@@ -17,7 +19,7 @@ defmodule CWMP.Protocol.Generator do
         'xmlns:xsd': "http://www.w3.org/2001/XMLSchema",
         'xmlns:cwmp': "urn:dslforum-org:cwmp-#{version}"
       },
-      [ element('SOAP-ENV:Header', [CWMP.Protocol.Generate.generate(head)]), element('SOAP-ENV:Body', [CWMP.Protocol.Generate.generate(req)]) ] ) |> generate;
+      [ element('SOAP-ENV:Header', [CWMP.Protocol.Generate.generate(head)]), element('SOAP-ENV:Body', [CWMP.Protocol.Generate.generate(req)]) ] )) |> generate;
   end
 
   @doc """


### PR DESCRIPTION
Various CPE require the arrayType attributes, otherwise the XML is rejected as invalid.